### PR TITLE
Detect panning only once a threshold has been crossed

### DIFF
--- a/src/plugin/MapboxMapGestureArea.qml
+++ b/src/plugin/MapboxMapGestureArea.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtQuick.Window 2.2
 import QtPositioning 5.3
 
 Item {
@@ -103,7 +104,7 @@ Item {
             property int __lastY: -1
 
             //! Required distance to be detected as panning
-            property int __panningThreshold: map.pixelRatio * 20
+            property int __panningThreshold: Screen.pixelDensity * 3
 
             anchors.fill : parent
 


### PR DESCRIPTION
I looked into into #32 and added a threshold that has to be crossed for a gesture to be detected as panning, thus keeping the map still when merely tapping.

Please test. `map.pixelRatio * 20` seemed to work for me on Sailfish X, but it would be good to test on a different screen. Secondly, I didn't really know if using `map.pixelRatio` is correct here, should it be something from QML Screen?