### PR TITLE
Update to support current Mapbox GL Native master

### DIFF
--- a/include/qquickitemmapboxgl.h
+++ b/include/qquickitemmapboxgl.h
@@ -321,7 +321,7 @@ private:
   void onMapChanged(QMapboxGL::MapChange change); ///< Follow the state of the map
   void onMapLoadingFailed(QMapboxGL::MapLoadingFailure type, const QString &description);
 
-  std::string resourceTransform(const std::string &&url); ///< Use resource transform API to change requested URL
+  std::string resourceTransform(const std::string &url); ///< Use resource transform API to change requested URL
 
   void setError(QString error); ///< Set error string, used internally
 

--- a/mapbox-gl-qml.pro
+++ b/mapbox-gl-qml.pro
@@ -21,7 +21,7 @@ HEADERS += \
 
 INCLUDEPATH += src/plugin
     
-LIBS += -lqmapboxgl -lz -L/opt/gcc6/lib -static-libstdc++
+LIBS += -lqmapboxgl -lz
 
 target.path=$$[QT_INSTALL_QML]/MapboxMap
 INSTALLS += target

--- a/rpm/mapbox-gl-qml.spec
+++ b/rpm/mapbox-gl-qml.spec
@@ -18,7 +18,8 @@ BuildRequires: pkgconfig(Qt5Location)
 BuildRequires: pkgconfig(Qt5Positioning)
 BuildRequires: pkgconfig(libcurl)
 BuildRequires: pkgconfig(openssl)
-BuildRequires: qmapboxgl
+BuildRequires: qmapboxgl-devel
+Requires: qmapboxgl
 
 %description
 QML plugin for Mapbox GL Native.

--- a/rpm/mapbox-gl-qml.spec
+++ b/rpm/mapbox-gl-qml.spec
@@ -10,7 +10,7 @@ Source: %{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
-BuildRequires: opt-gcc gcc-c++
+BuildRequires: gcc-c++
 BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: pkgconfig(Qt5Quick)
 BuildRequires: pkgconfig(Qt5Qml)
@@ -31,7 +31,7 @@ QML plugin for Mapbox GL Native.
 
 %qmake5 'CONFIG+=use_curl_ssl' VERSION='%{version}-%{release}' mapbox-gl-qml.pro
 
-%{__make} CXX=/opt/gcc/bin/g++ CC=/opt/gcc/bin/gcc LINK=/opt/gcc/bin/g++ %{?_smp_mflags}
+%{__make} %{?_smp_mflags}
 
 %install
 %{__rm} -rf %{buildroot}

--- a/src/qquickitemmapboxgl.cpp
+++ b/src/qquickitemmapboxgl.cpp
@@ -1059,7 +1059,7 @@ void QQuickItemMapboxGL::setUrlSuffix(const QString &urlsfx)
   emit urlSuffixChanged(urlsfx);
 }
 
-std::string QQuickItemMapboxGL::resourceTransform(const std::string &&url)
+std::string QQuickItemMapboxGL::resourceTransform(const std::string &url)
 {
   QMutexLocker lk(&m_resourceTransformMutex);
   std::string newurl = url + m_urlSuffix;

--- a/src/qsgmapboxglnode.cpp
+++ b/src/qsgmapboxglnode.cpp
@@ -114,6 +114,7 @@ bool QSGMapboxGLTextureNode::render(QQuickWindow *window)
 
   // QTBUG-62861
   f->glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+  f->glDepthRangef(0, 1);
 
   window->resetOpenGLState();
   markDirty(QSGNode::DirtyMaterial);


### PR DESCRIPTION
This makes required updates to support current Mapbox GL Native master. From now on it is planned to support that instead of QMapboxGL as distributed via Qt Location.