### PR TITLE
Fix framebuffer method for compatibility with recent MapLibre versions

### DIFF
--- a/src/qsgmapboxglnode.cpp
+++ b/src/qsgmapboxglnode.cpp
@@ -149,7 +149,7 @@ void QSGMapboxGLTextureNode::resize(const QSize &size, qreal pixelRatio)
   m_map->resize(m_map_size);
 
   m_fbo.reset(new QOpenGLFramebufferObject(fbSize, QOpenGLFramebufferObject::CombinedDepthStencil));
-  m_map->setFramebufferObject(m_fbo->handle(), fbSize); //minSize);
+  m_map->setOpenGLFramebufferObject(m_fbo->handle(), fbSize);
 
   QSGTexturePlain *fboTexture = static_cast<QSGTexturePlain *>(texture());
   if (!fboTexture)


### PR DESCRIPTION
During the compilation of qsgmapboxglnode.cpp, the error occurs due to the setFramebufferObject method, which does not exist in the QMapLibre::Map class. I believe the correct method to use is setOpenGLFramebufferObject.
Reference:
https://maplibre.org/maplibre-native-qt/docs/functions_func.html